### PR TITLE
Fix service restart on ADC reference calibration errors

### DIFF
--- a/software/rocketlogger/config/rocketlogger.service
+++ b/software/rocketlogger/config/rocketlogger.service
@@ -2,6 +2,8 @@
 [Unit]
 Description=RocketLogger daemon
 Documentation=https://github.com/ETHZ-TEC/RocketLogger#readme
+StartLimitIntervalSec=30s
+StartLimitBurst=5
 
 [Service]
 Type=simple


### PR DESCRIPTION
* terminate the rocketlogger daemon to allow service restart on ADC reference calibration errors
* limit number of service restarts to shop after 5 subsequent unsuccessful restarts

Fixes: #50