### PR TITLE
Remove debugging related console output in Python support library

### DIFF
--- a/script/python/rocketlogger/data.py
+++ b/script/python/rocketlogger/data.py
@@ -769,7 +769,6 @@ class RocketLoggerData:
         while True:
             # skip excluded files
             if file_number in exclude_part:
-                print(f"Skipping part {file_number}")
                 file_number = file_number + 1
                 continue
 
@@ -921,7 +920,6 @@ class RocketLoggerData:
         )
 
         self._filename = filename
-        print(f"Read {files_loaded} file(s)")
 
     def get_channel_names(self):
         """
@@ -1187,10 +1185,6 @@ class RocketLoggerData:
                 self.remove_channel(candidate["low"])
                 self.remove_channel(candidate["high"])
 
-            print(
-                f"Merged channels '{candidate['low']}' and '{candidate['high']}' "
-                f"to '{candidate['merged']}'."
-            )
             merged_channels = True
 
         if not merged_channels:


### PR DESCRIPTION
remove debugging related console output in Python support library
* verified the removed output in unexpected corner cases is covered by warnings or errors
* remaining console outputs are only found  in explicit `print_*` functionality

Fixes: #46