### PR TITLE
Fix file version documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ RocketLogger software:
 * [CHANGED] rework low level hardware interfacing for Debian *buster* compatibility (#2)
 * [CHANGED] update and reorganize internal software API and headers for increased consistency
 * [CHANGED] update to latest and official compiler tools (#18)
+* [CHANGED] Binary file format: increment file version to `0x04`
 * [REMOVED] legacy web control interface
 
 Python support library:

--- a/script/python/LICENSE
+++ b/script/python/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2016-2020, ETH Zurich, Computer Engineering Group
+Copyright (c) 2020-2021, Lukas Sigrist <lsigrist@mailbox.org>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/script/python/README.md
+++ b/script/python/README.md
@@ -12,6 +12,10 @@ support to generate calibration data from measurements.
 * Matplotlib: for plotting data overview
 * pandas: for pandas DataFrame export
 
+**Compatibility**
+* Data processing: supports all officially specified RLD file version (versions 2-4)
+* Calibration: compatible with RocketLogger calibration file version 2
+
 
 ## Installation
 


### PR DESCRIPTION
* add missing changelog entry for change to RLD file format version 4
* document RLD file versions supported by the Python library

Fixes: #61