### PR TITLE
Hardware based timestamping using PRU IEP timer capture

### DIFF
--- a/software/rocketlogger/calibration.c
+++ b/software/rocketlogger/calibration.c
@@ -108,6 +108,10 @@ int calibration_load(void) {
 
     memcpy(&rl_calibration, &(calibration_file.data), sizeof(rl_calibration_t));
 
+    // PRU DT channel has implementation specific, fixed conversion
+    rl_calibration.offsets[RL_CONFIG_CHANNEL_DT] = 0;
+    rl_calibration.scales[RL_CONFIG_CHANNEL_DT] = 5;
+
     // store calibration info information to status
     rl_status.calibration_time = calibration_file.calibration_time;
     strncpy(rl_status.calibration_file, calibration_file_name,

--- a/software/rocketlogger/overlay/ROCKETLOGGER.dts
+++ b/software/rocketlogger/overlay/ROCKETLOGGER.dts
@@ -73,6 +73,7 @@
     "P9.31",
     "P8.15",
     "P8.16",
+    "P9.20",
 
     "P9.14", /* PWM pins */
     "P9.16",
@@ -101,6 +102,7 @@
       P9_31_pinmux { status = "disabled"; }; /* SCLK pin, PRU0 controlled */
       P8_15_pinmux { status = "disabled"; }; /* DR1 pin, PRU0 controlled */
       P8_16_pinmux { status = "disabled"; }; /* DR0 pin, PRU0 controlled */
+      P9_20_pinmux { status = "disabled"; }; /* DR0 pin, PRU-ICSS IEP edc_latch0_in */
       P9_11_pinmux { status = "disabled"; }; /* nForce high range 1 pin */
       P9_12_pinmux { status = "disabled"; }; /* nForce high range 2 pin */
       P8_11_pinmux { status = "disabled"; }; /* Status LED pin, MUX_MODE7 for GPIO, MUX_MODE6 for PRU0 controlled */
@@ -143,8 +145,9 @@
           BONE_P9_29 (PIN_OUTPUT_PULLDOWN | MUX_MODE5) /* MOSI pin, PRU0 controlled */
           BONE_P9_30 (PIN_INPUT_PULLDOWN | MUX_MODE6) /* MISO0 pin, PRU0 controlled */
           BONE_P9_31 (PIN_OUTPUT_PULLDOWN | MUX_MODE5) /* SCLK pin, PRU0 controlled */
-          BONE_P8_15 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR1 pin, PRU0 controlled */
-          BONE_P8_16 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR0 pin, PRU0 controlled */
+          BONE_P8_15 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR0 pin, PRU0 controlled */
+          BONE_P8_16 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR1 pin, PRU0 controlled */
+          BONE_P9_20 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR0 pin, PRU-ICSS IEP edc_latch0_in */
         >;
       };
 

--- a/software/rocketlogger/overlay/ROCKETLOGGER.dts
+++ b/software/rocketlogger/overlay/ROCKETLOGGER.dts
@@ -73,7 +73,7 @@
     "P9.31",
     "P8.15",
     "P8.16",
-    "P9.20",
+    "P9.19",
 
     "P9.14", /* PWM pins */
     "P9.16",
@@ -102,7 +102,7 @@
       P9_31_pinmux { status = "disabled"; }; /* SCLK pin, PRU0 controlled */
       P8_15_pinmux { status = "disabled"; }; /* DR1 pin, PRU0 controlled */
       P8_16_pinmux { status = "disabled"; }; /* DR0 pin, PRU0 controlled */
-      P9_20_pinmux { status = "disabled"; }; /* DR0 pin, PRU-ICSS IEP edc_latch0_in */
+      P9_19_pinmux { status = "disabled"; }; /* DR0 pin, PRU-ICSS IEP edc_latch1_in */
       P9_11_pinmux { status = "disabled"; }; /* nForce high range 1 pin */
       P9_12_pinmux { status = "disabled"; }; /* nForce high range 2 pin */
       P8_11_pinmux { status = "disabled"; }; /* Status LED pin, MUX_MODE7 for GPIO, MUX_MODE6 for PRU0 controlled */
@@ -147,7 +147,7 @@
           BONE_P9_31 (PIN_OUTPUT_PULLDOWN | MUX_MODE5) /* SCLK pin, PRU0 controlled */
           BONE_P8_15 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR0 pin, PRU0 controlled */
           BONE_P8_16 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR1 pin, PRU0 controlled */
-          BONE_P9_20 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR0 pin, PRU-ICSS IEP edc_latch0_in */
+          BONE_P9_19 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR0 pin, PRU-ICSS IEP edc_latch1_in */
         >;
       };
 

--- a/software/rocketlogger/pru/rocketlogger.asm
+++ b/software/rocketlogger/pru/rocketlogger.asm
@@ -370,66 +370,66 @@ timestamp_restart .macro reg
 
 
 ; ---------------------------- IEP Timer Macros ----------------------------- ;
-; IEP TIMER INIT
+; IEP TIMER INITIALIZATION
 ; (initialize the IEP timer in free runing mode with capture compare input)
 iep_timer_init .macro
     ; set global configuration with enable bit cleared
-    LDI     &MTMP_REG, IEP_TMR_GLB_CFG_CONFIG
-    CLR     &MTMP_REG, IEP_TMR_GLB_CFG_CNT_ENABLE_BIT
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_CFG_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_GLB_CFG_CONFIG
+    CLR     MTMP_REG, MTMP_REG, IEP_TMR_GLB_CFG_CNT_ENABLE_BIT
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_GLB_CFG_OFFSET, 4
 
     ; reset counter register by writing all bits set
     ZERO    &MTMP_REG, 4
-    NOT     &MTMP_REG, MTMP_REG
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CNT_OFFSET, 4
+    NOT     MTMP_REG, MTMP_REG
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CNT_OFFSET, 4
 
     ; clear counter overflow flag
-    LDI     &MTMP_REG, IEP_TMR_GLB_STS_CNT_OVF_MASK
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_STS_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_GLB_STS_CNT_OVF_MASK
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_GLB_STS_OFFSET, 4
 
     ; set compensation configuration
-    LDI     &MTMP_REG, IEP_TMR_COMPEN_CONFIG
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_COMPEN_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_COMPEN_CONFIG
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_COMPEN_OFFSET, 4
 
     ; set capture configuration
-    LDI     &MTMP_REG, IEP_TMR_CAP_CFG_CONFIG
-    SET     &MTMP_REG, TMP_REG, IEP_TMR_CMP_STS_CAPF6_VALID_BIT
-
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_CFG_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_CAP_CFG_CONFIG
+    SET     MTMP_REG, MTMP_REG, IEP_TMR_CMP_CFG_CAPF6_EN_BIT
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAP_CFG_OFFSET, 4
 
     ; clear capture state by register read
-    LBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_STS_OFFSET, 4
+    LBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAP_STS_OFFSET, 4
 
     ; set global configuration with enable
-    LDI     &MTMP_REG, IEP_TMR_GLB_CFG_CONFIG
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_CFG_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_GLB_CFG_CONFIG
+    SET     MTMP_REG, MTMP_REG, IEP_TMR_GLB_CFG_CNT_ENABLE_BIT
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_GLB_CFG_OFFSET, 4
     .endm
 
 
-; IEP TIMER RESET
-; (stop the IEP timer and reset to default values)
-iep_timer_reset .macro
+; IEP TIMER DE-INITIALIZATION
+; (stop the IEP timer and reset registers to default values)
+iep_timer_deinit .macro
     ; reset global timer config to zero to stop initial zero state
-    LDI     &MTMP_REG, IEP_TMR_GLB_CFG_RESET
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_CFG_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_GLB_CFG_RESET
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_GLB_CFG_OFFSET, 4
 
     ; reset counter register by writing all bits set
     ZERO    &MTMP_REG, 4
-    NOT     &MTMP_REG, MTMP_REG
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CNT_OFFSET, 4
+    NOT     MTMP_REG, MTMP_REG
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CNT_OFFSET, 4
 
     ; reset compensation and capture config to initial zero state
-    LDI     &MTMP_REG, IEP_TMR_COMPEN_RESET
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_COMPEN_OFFSET, 4
-    LDI     &MTMP_REG, IEP_TMR_CAP_CFG_RESET
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_CFG_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_COMPEN_RESET
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_COMPEN_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_CAP_CFG_RESET
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAP_CFG_OFFSET, 4
 
     ; clear overflow flag
-    LDI     &MTMP_REG, IEP_TMR_GLB_STS_CNT_OVF_MASK
-    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_STS_OFFSET, 4
+    LDI     MTMP_REG, IEP_TMR_GLB_STS_CNT_OVF_MASK
+    SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_GLB_STS_OFFSET, 4
 
     ; clear capture state by register read
-    LBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_STS_OFFSET, 4
+    LBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAP_STS_OFFSET, 4
     .endm
 
 
@@ -440,9 +440,9 @@ iep_timer_capture_read .macro
     ZERO    &TIME_REG, 4
 
     ; check if new CAPF6 (pr1_edc_latch0, P9_20) value was captured and read if available
-    LBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_STS_OFFSET, 4
+    LBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAP_STS_OFFSET, 4
     QBBC    RETURN?, MTMP_REG, IEP_TMR_CMP_STS_CAPF6_VALID_BIT
-    LBCO    &TIME_REG, C_PRU_IEP, IEP_TMR_CAPF6_OFFSET, 4
+    LBCO    &TIME_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAPF6_OFFSET, 4
 RETURN?:
     .endm
 

--- a/software/rocketlogger/pru/rocketlogger.asm
+++ b/software/rocketlogger/pru/rocketlogger.asm
@@ -31,226 +31,300 @@
 
 ; ------------------------- PRU Memory Definitions -------------------------- ;
 ; PRU control and data RAM address definitions
-PRU0_DATA_RAM_BASE          .set    0x00000000
-PRU0_CTRL_BASE              .set    0x00022000
+PRU0_DATA_RAM_BASE              .set    0x00000000
+PRU0_CTRL_BASE                  .set    0x00022000
 
 ; PRU control register definitions
-PRU_CTRL_BASE               .set    PRU0_CTRL_BASE
-PRU_CTRL_OFFSET             .set    0x00
-PRU_CYCLE_OFFSET            .set    0x0C
-PRU_CYCLE_RESET             .set    0x0000
+PRU_CTRL_BASE                   .set    PRU0_CTRL_BASE
+PRU_CTRL_OFFSET                 .set    0x00
+PRU_CYCLE_OFFSET                .set    0x0C
+PRU_CYCLE_RESET                 .set    0x0000
 
 ; PRU control register LS byte constants for cycle counter control
-PRU_CRTL_CTR_ON             .set    0x0B
-PRU_CRTL_CTR_OFF            .set    0x03
+PRU_CRTL_CTR_ON                 .set    0x0B
+PRU_CRTL_CTR_OFF                .set    0x03
 
 ; PRU interrupt event register definitions
-PRU_R31_VEC_VALID           .set    0x20    ; valid interrupt bit flag
-PRU_EVTOUT_0                .set    0x03    ; user space interrupt event number
+PRU_R31_VEC_VALID               .set    0x20    ; valid interrupt bit flag
+PRU_EVTOUT_0                    .set    0x03    ; user space interrupt event number
 
 ; PRU constants table alias definitions
-C_PRU_INTC                  .set    C0      ; PRU-ICSS INTC (local) 0x0002_0000
-C_PRU_ECAP                  .set    C3      ; PRU-ICSS eCAP (local) 0x0003_0000
-C_PRU_CFG                   .set    C4      ; PRU-ICSS CFG (local) 0x0002_6000
-C_EHRPWM0                   .set    C18     ; eHRPWM0/eCAP0/eQEP0 0x4830_0000
-C_EHRPWM1                   .set    C19     ; eHRPWM1/eCAP1/eQEP1 0x4830_2000
-C_EHRPWM2                   .set    C20     ; eHRPWM1/eCAP1/eQEP1 0x4830_4000
+C_PRU_INTC                      .set    C0      ; PRU-ICSS INTC (local) 0x0002_0000
+C_PRU_ECAP                      .set    C3      ; PRU-ICSS eCAP (local) 0x0003_0000
+C_PRU_CFG                       .set    C4      ; PRU-ICSS CFG (local) 0x0002_6000
+C_EHRPWM0                       .set    C18     ; eHRPWM0/eCAP0/eQEP0 0x4830_0000
+C_EHRPWM1                       .set    C19     ; eHRPWM1/eCAP1/eQEP1 0x4830_2000
+C_EHRPWM2                       .set    C20     ; eHRPWM1/eCAP1/eQEP1 0x4830_4000
+C_PRU_IEP                       .set    C26     ; PRU-ICSS IEP (local) 0x0002_E000 (reset value, configurable)
 
 ; PRU data layout (address offets in PRU local memory)
-STATE_OFFSET                .set    0x00
-SAMPLE_RATE_OFFSET          .set    0x04
-SAMPLE_LIMIT_OFFSET         .set    0x08
-BUFFER_LENGTH_OFFSET        .set    0x0C
-BUFFER0_ADDR_OFFSET         .set    0x10
-BUFFER1_ADDR_OFFSET         .set    0x14
+STATE_OFFSET                    .set    0x00
+SAMPLE_RATE_OFFSET              .set    0x04
+SAMPLE_LIMIT_OFFSET             .set    0x08
+BUFFER_LENGTH_OFFSET            .set    0x0C
+BUFFER0_ADDR_OFFSET             .set    0x10
+BUFFER1_ADDR_OFFSET             .set    0x14
 
 ; shared DDR buffer data layout
-BUFFER_CHANNEL_COUNT        .set    10
-BUFFER_INDEX_SIZE           .set    4
-BUFFER_DATA_SIZE            .set    4
-BUFFER_BLOCK_SIZE           .set    (BUFFER_CHANNEL_COUNT * BUFFER_DATA_SIZE)
+BUFFER_CHANNEL_COUNT            .set    10
+BUFFER_INDEX_SIZE               .set    4
+BUFFER_DATA_SIZE                .set    4
+BUFFER_BLOCK_SIZE               .set    (BUFFER_CHANNEL_COUNT * BUFFER_DATA_SIZE)
 
 
 ; -------------------------- PRU Register Mappings -------------------------- ;
 ; Status GPIO in/out register bit definitions
-STATUS_OUT_REG              .set    r30
-LED_ERROR_BIT               .set    14      ; user space, cleared on start
-LED_STATUS_BIT              .set    15      ; user space, busy wait indicator
+STATUS_OUT_REG                  .set    r30
+LED_ERROR_BIT                   .set    14      ; user space, cleared on start
+LED_STATUS_BIT                  .set    15      ; user space, busy wait indicator
 
 ; ADC GPIO in/out register and bit definitions
-ADC_OUT_REG                 .set    r30
-SCLK_BIT                    .set    0
-MOSI_BIT                    .set    1
-CS1_BIT                     .set    3
-CS2_BIT                     .set    5
-START_BIT                   .set    7
-ADC_IN_REG                  .set    r31
-MISO1_BIT                   .set    2
-MISO2_BIT                   .set    16
-DR1_BIT                     .set    15
-DR2_BIT                     .set    14
+ADC_OUT_REG                     .set    r30
+SCLK_BIT                        .set    0
+MOSI_BIT                        .set    1
+CS1_BIT                         .set    3
+CS2_BIT                         .set    5
+START_BIT                       .set    7
+ADC_IN_REG                      .set    r31
+MISO1_BIT                       .set    2
+MISO2_BIT                       .set    16
+DR1_BIT                         .set    15
+DR2_BIT                         .set    14
 
 ; PRU register definitions: channel data from ADC to transfer to DDR
-DI_REG                      .set    r0
-V1_REG                      .set    r1
-V2_REG                      .set    r2
-V3_REG                      .set    r3
-V4_REG                      .set    r4
-I1L_REG                     .set    r5
-I1H_REG                     .set    r6
-I2L_REG                     .set    r7
-I2H_REG                     .set    r8
-DT_REG                      .set    r9      ; PRU cycle counter
+DI_REG                          .set    r0
+V1_REG                          .set    r1
+V2_REG                          .set    r2
+V3_REG                          .set    r3
+V4_REG                          .set    r4
+I1L_REG                         .set    r5
+I1H_REG                         .set    r6
+I2L_REG                         .set    r7
+I2H_REG                         .set    r8
+DT_REG                          .set    r9      ; PRU cycle counter
 
 ; PRU register definitions: double sampled channel data from ADC
-I1L_2_REG                   .set    r10
-I1H_2_REG                   .set    r11
-I2L_2_REG                   .set    r12
-I2H_2_REG                   .set    r13
+I1L_2_REG                       .set    r10
+I1H_2_REG                       .set    r11
+I2L_2_REG                       .set    r12
+I2H_2_REG                       .set    r13
 
 ; PRU register definitions: unused medium current channel data from ADC
-I1M_REG                     .set    r14     ; unused ADC data
-I2M_REG                     .set    r15     ; unused ADC data
+I1M_REG                         .set    r14     ; unused ADC data
+I2M_REG                         .set    r15     ; unused ADC data
 
 ; PRU register definitions: temporary registers
-TMP_REG                     .set    r16
+TMP_REG                         .set    r16
 
 ; PRU register definitions: temporary macro register
-MTMP_REG                    .set    r17
+MTMP_REG                        .set    r17
 
 ; PRU register definitions: data memory addresses
-RAM_ADDRESS                 .set    r29
-CTRL_ADDRESS                .set    r28
+RAM_ADDRESS                     .set    r29
+CTRL_ADDRESS                    .set    r28
 
 ; PRU register definitions: PRU local sampling state
-BUFFER_SIZE                 .set    r27
-BUFFER_INDEX                .set    r26
-SAMPLES_COUNT               .set    r25
-MEM_POINTER                 .set    r24
-PRECISION                   .set    r23
+BUFFER_SIZE                     .set    r27
+BUFFER_INDEX                    .set    r26
+SAMPLES_COUNT                   .set    r25
+MEM_POINTER                     .set    r24
+PRECISION                       .set    r23
 
 ; PRU register definitions: PRU user space configuration
-SAMPLE_RATE                 .set    r22
+SAMPLE_RATE                     .set    r22
 
 ; registers r18-r21 unused
 
 ; PRU register definitions: ADC status and configuration register aliases
-ADC1_STATUS_REG             .set    DI_REG
-ADC2_STATUS_REG             .set    TMP_REG
+ADC1_STATUS_REG                 .set    DI_REG
+ADC2_STATUS_REG                 .set    TMP_REG
 
 
 ; ---------------------- CLOCK MANAGEMENT Definitions ----------------------- ;
 ; clock managment register offsets
-CM_PER_BASE                 .set    0x44E00000
-CM_PER_EPWMSS1_OFFSET       .set    0xCC
-CM_PER_EPWMSS0_OFFSET       .set    0xD4
-CM_PER_EPWMSS2_OFFSET       .set    0xD8
+CM_PER_BASE                     .set    0x44E00000
+CM_PER_EPWMSS1_OFFSET           .set    0xCC
+CM_PER_EPWMSS0_OFFSET           .set    0xD4
+CM_PER_EPWMSS2_OFFSET           .set    0xD8
 
 ; clock managements register values (selection)
-CM_MODULEMODE_DISABLE       .set    0x00
-CM_MODULEMODE_ENABLE        .set    0x02
-CM_IDLESTATUS_FUNC          .set    0x000000
-CM_IDLESTATUS_TRANS         .set    0x010000
-CM_IDLESTATUS_IDLE          .set    0x020000
-CM_IDLESTATUS_DISABLE       .set    0x030000
+CM_MODULEMODE_DISABLE           .set    0x00
+CM_MODULEMODE_ENABLE            .set    0x02
+CM_IDLESTATUS_FUNC              .set    0x000000
+CM_IDLESTATUS_TRANS             .set    0x010000
+CM_IDLESTATUS_IDLE              .set    0x020000
+CM_IDLESTATUS_DISABLE           .set    0x030000
 
 
 ; --------------------------- CONTROL Definitions --------------------------- ;
 ; control register offsets and PWMSS values (selection)
-CONTROL_PWMSS_CTRL          .set    0x44E10664
-PWMSS_CTRL_PWMSS_RESET      .set    0x00
-PWMSS_CTRL_PWMSS0_TBCLKEN   .set    0x01
-PWMSS_CTRL_PWMSS1_TBCLKEN   .set    0x02
-PWMSS_CTRL_PWMSS2_TBCLKEN   .set    0x04
+CONTROL_PWMSS_CTRL              .set    0x44E10664
+PWMSS_CTRL_PWMSS_RESET          .set    0x00
+PWMSS_CTRL_PWMSS0_TBCLKEN       .set    0x01
+PWMSS_CTRL_PWMSS1_TBCLKEN       .set    0x02
+PWMSS_CTRL_PWMSS2_TBCLKEN       .set    0x04
 
 
 ; ----------------------------- PWM Definitions ----------------------------- ;
 ; ePWM module and configuration register offsets
-EPWM0_BASE                  .set    0x48300200  ; ePWM0 module base address
-EPWM1_BASE                  .set    0x48302200  ; ePWM1 module base address
-EPWM2_BASE                  .set    0x48304200  ; ePWM2 module base address
-EPWM_TBCTL_OFFSET           .set    0x00    ; Time-Base Control Register
-EPWM_TBSTS_OFFSET           .set    0x02    ; Time-Base Status Register
-EPWM_TBPHS_OFFSET           .set    0x06    ; Time-Base Phase Register
-EPWM_TBCNT_OFFSET           .set    0x08    ; Time-Base Counter Register
-EPWM_TBPRD_OFFSET           .set    0x0A    ; Time-Base Period Register
-EPWM_CMPCTL_OFFSET          .set    0x0E    ; Counter-Compare Control Register
-EPWM_CMPA_OFFSET            .set    0x12    ; Counter-Compare A Register
-EPWM_CMPB_OFFSET            .set    0x14    ; Counter-Compare B Register
-EPWM_AQCTLA_OFFSET          .set    0x16    ; Action-Qualifier Control Register for Output A (EPWMxA)
-EPWM_AQCTLB_OFFSET          .set    0x18    ; Action-Qualifier Control Register for Output B (EPWMxB)
+EPWM0_BASE                      .set    0x48300200  ; ePWM0 module base address
+EPWM1_BASE                      .set    0x48302200  ; ePWM1 module base address
+EPWM2_BASE                      .set    0x48304200  ; ePWM2 module base address
+EPWM_TBCTL_OFFSET               .set    0x00    ; Time-Base Control Register
+EPWM_TBSTS_OFFSET               .set    0x02    ; Time-Base Status Register
+EPWM_TBPHS_OFFSET               .set    0x06    ; Time-Base Phase Register
+EPWM_TBCNT_OFFSET               .set    0x08    ; Time-Base Counter Register
+EPWM_TBPRD_OFFSET               .set    0x0A    ; Time-Base Period Register
+EPWM_CMPCTL_OFFSET              .set    0x0E    ; Counter-Compare Control Register
+EPWM_CMPA_OFFSET                .set    0x12    ; Counter-Compare A Register
+EPWM_CMPB_OFFSET                .set    0x14    ; Counter-Compare B Register
+EPWM_AQCTLA_OFFSET              .set    0x16    ; Action-Qualifier Control Register for Output A (EPWMxA)
+EPWM_AQCTLB_OFFSET              .set    0x18    ; Action-Qualifier Control Register for Output B (EPWMxB)
 
 ; ePWM configuration register values (selection)
-TBCTL_FREERUN               .set    0xC000  ; TBCTL default value after reset
-TBCTL_COUNT_UP              .set    0x0000  ; Up counting mode
-TBCTL_COUNT_UP_DOWN         .set    0x0002  ; Up-down counting mode
-TBCTL_PRDLD                 .set    0x0008  ; Period register double buffer disable
-TBCTL_CLKDIV_1              .set    0x0000  ; Use counter clock prescaler of 1
-TBCTL_CLKDIV_2              .set    0x0400  ; Use counter clock prescaler of 2
+TBCTL_FREERUN                   .set    0xC000  ; TBCTL default value after reset
+TBCTL_COUNT_UP                  .set    0x0000  ; Up counting mode
+TBCTL_COUNT_UP_DOWN             .set    0x0002  ; Up-down counting mode
+TBCTL_PRDLD                     .set    0x0008  ; Period register double buffer disable
+TBCTL_CLKDIV_1                  .set    0x0000  ; Use counter clock prescaler of 1
+TBCTL_CLKDIV_2                  .set    0x0400  ; Use counter clock prescaler of 2
 
-AQ_ZROCLR                   .set    0x0001  ; Action qualifier: clear on zero
-AQ_ZROSET                   .set    0x0002  ; Action qualifier: set on zero
-AQ_PRDCLR                   .set    0x0004  ; Action qualifier: clear on period
-AQ_PRDSET                   .set    0x0008  ; Action qualifier: clear set on period
-AQ_A_INCCLR                 .set    0x0010  ; Action qualifier: clear on compare A when incrementing
-AQ_A_INCSET                 .set    0x0020  ; Action qualifier: set on compare A when incrementing
-AQ_A_DECCLR                 .set    0x0040  ; Action qualifier: clear on compare A when decrementing
-AQ_A_DECSET                 .set    0x0080  ; Action qualifier: set on compare A when decrementing
-AQ_B_INCCLR                 .set    0x0100  ; Action qualifier: clear on compare B when incrementing
-AQ_B_INCSET                 .set    0x0200  ; Action qualifier: set on compare B when incrementing
-AQ_B_DECCLR                 .set    0x0400  ; Action qualifier: clear on compare B when decrementing
-AQ_B_DECSET                 .set    0x0800  ; Action qualifier: set on compare B when decrementing
+AQ_ZROCLR                       .set    0x0001  ; Action qualifier: clear on zero
+AQ_ZROSET                       .set    0x0002  ; Action qualifier: set on zero
+AQ_PRDCLR                       .set    0x0004  ; Action qualifier: clear on period
+AQ_PRDSET                       .set    0x0008  ; Action qualifier: clear set on period
+AQ_A_INCCLR                     .set    0x0010  ; Action qualifier: clear on compare A when incrementing
+AQ_A_INCSET                     .set    0x0020  ; Action qualifier: set on compare A when incrementing
+AQ_A_DECCLR                     .set    0x0040  ; Action qualifier: clear on compare A when decrementing
+AQ_A_DECSET                     .set    0x0080  ; Action qualifier: set on compare A when decrementing
+AQ_B_INCCLR                     .set    0x0100  ; Action qualifier: clear on compare B when incrementing
+AQ_B_INCSET                     .set    0x0200  ; Action qualifier: set on compare B when incrementing
+AQ_B_DECCLR                     .set    0x0400  ; Action qualifier: clear on compare B when decrementing
+AQ_B_DECSET                     .set    0x0800  ; Action qualifier: set on compare B when decrementing
 
 ; ePWM configuration values for ADC clock and range reset pulses
-PWM_ADC_CLOCK_PERIOD        .set    49              ; ADC master clock period (in units of 10 ns)
-PWM_RANGE_RESET_PERIOD_BASE .set    (50000 + 5000)  ; Range latch base period, 0.5 kHz + 10% margin (in units of 10 ns)
-PWM_RANGE_RESET_PULSE_WIDTH .set    50              ; Range latch reset pulse width (in units of 10 ns)
+PWM_ADC_CLOCK_PERIOD            .set    49              ; ADC master clock period (in units of 10 ns)
+PWM_RANGE_RESET_PERIOD_BASE     .set    (50000 + 5000)  ; Range latch base period, 0.5 kHz + 10% margin (in units of 10 ns)
+PWM_RANGE_RESET_PULSE_WIDTH     .set    50              ; Range latch reset pulse width (in units of 10 ns)
+
+
+; ------------------------ PRU-ICSS IEP Definitions ------------------------- ;
+; PRU-ICSS IEP module and configuration register offsets
+PRU_ICSS_IEP_BASE_CONST         .set    C_PRU_IEP
+IEP_TMR_GLB_CFG_OFFSET          .set    0x0000  ; IEP_TMR_GLB_CFG register address offset
+IEP_TMR_GLB_STS_OFFSET          .set    0x0004  ; IEP_TMR_GLB_STS register address offset
+IEP_TMR_COMPEN_OFFSET           .set    0x0008  ; IEP_TMR_COMPEN register address offset
+IEP_TMR_CNT_OFFSET              .set    0x000C  ; IEP_TMR_CNT register address offset
+IEP_TMR_CAP_CFG_OFFSET          .set    0x0010  ; IEP_TMR_CAP_CFG register address offset
+IEP_TMR_CAP_STS_OFFSET          .set    0x0014  ; IEP_TMR_CAP_STS register address offset
+IEP_TMR_CAPR0_OFFSET            .set    0x0018  ; IEP_TMR_CAPR0 register address offset
+IEP_TMR_CAPR1_OFFSET            .set    0x001C  ; IEP_TMR_CAPR1 register address offset
+IEP_TMR_CAPR2_OFFSET            .set    0x0020  ; IEP_TMR_CAPR2 register address offset
+IEP_TMR_CAPR3_OFFSET            .set    0x0024  ; IEP_TMR_CAPR3 register address offset
+IEP_TMR_CAPR4_OFFSET            .set    0x0028  ; IEP_TMR_CAPR4 register address offset
+IEP_TMR_CAPR5_OFFSET            .set    0x002C  ; IEP_TMR_CAPR5 register address offset
+IEP_TMR_CAPR6_OFFSET            .set    0x0030  ; IEP_TMR_CAPR6 register address offset
+IEP_TMR_CAPF6_OFFSET            .set    0x0034  ; IEP_TMR_CAPF6 register address offset
+IEP_TMR_CAPR7_OFFSET            .set    0x0038  ; IEP_TMR_CAPR7 register address offset
+IEP_TMR_CAPF7_OFFSET            .set    0x003C  ; IEP_TMR_CAPF7 register address offset
+IEP_TMR_CMP_CFG_OFFSET          .set    0x0040  ; IEP_TMR_CMP_CFG register address offset
+IEP_TMR_CMP_STS_OFFSET          .set    0x0044  ; IEP_TMR_CMP_STS register address offset
+IEP_TMR_CMP0_OFFSET             .set    0x0048  ; IEP_TMR_CMP0 register address offset
+IEP_TMR_CMP1_OFFSET             .set    0x004C  ; IEP_TMR_CMP1 register address offset
+IEP_TMR_CMP2_OFFSET             .set    0x0050  ; IEP_TMR_CMP2 register address offset
+IEP_TMR_CMP3_OFFSET             .set    0x0054  ; IEP_TMR_CMP3 register address offset
+IEP_TMR_CMP4_OFFSET             .set    0x0058  ; IEP_TMR_CMP4 register address offset
+IEP_TMR_CMP5_OFFSET             .set    0x005C  ; IEP_TMR_CMP5 register address offset
+IEP_TMR_CMP6_OFFSET             .set    0x0060  ; IEP_TMR_CMP6 register address offset
+IEP_TMR_CMP7_OFFSET             .set    0x0064  ; IEP_TMR_CMP7 register address offset
+IEP_TMR_RXIPG0_OFFSET           .set    0x0080  ; IEP_TMR_RXIPG0 register address offset
+IEP_TMR_RXIPG1_OFFSET           .set    0x0084  ; IEP_TMR_RXIPG1 register address offset
+IEP_SYNC_CTRL_OFFSET            .set    0x0100  ; IEP_SYNC_CTRL register address offset
+IEP_SYNC_FIRST_STAT_OFFSET      .set    0x0104  ; IEP_SYNC_FIRST_STAT register address offset
+IEP_SYNC0_STAT_OFFSET           .set    0x0108  ; IEP_SYNC0_STAT register address offset
+IEP_SYNC1_STAT_OFFSET           .set    0x010C  ; IEP_SYNC1_STAT register address offset
+IEP_SYNC_PWIDTH_OFFSET          .set    0x0110  ; IEP_SYNC_PWIDTH register address offset
+IEP_SYNC0_PERIOD_OFFSET         .set    0x0114  ; IEP_SYNC0_PERIOD register address offset
+IEP_SYNC1_DELAY_OFFSET          .set    0x0118  ; IEP_SYNC1_DELAY register address offset
+IEP_SYNC_START_OFFSET           .set    0x011C  ; IEP_SYNC_START register address offset
+IEP_WD_PREDIV_OFFSET            .set    0x0200  ; IEP_WD_PREDIV register address offset
+IEP_PDI_WD_TIM_OFFSET           .set    0x0204  ; IEP_PDI_WD_TIM register address offset
+IEP_PD_WD_TIM_OFFSET            .set    0x0208  ; IEP_PD_WD_TIM register address offset
+IEP_WD_STATUS_OFFSET            .set    0x020C  ; IEP_WD_STATUS register address offset
+IEP_WD_EXP_CNT_OFFSET           .set    0x0210  ; IEP_WD_EXP_CNT register address offset
+IEP_WD_CTRL_OFFSET              .set    0x0214  ; IEP_WD_CTRL register address offset
+IEP_DIGIO_CTRL_OFFSET           .set    0x0300  ; IEP_DIGIO_CTRL register address offset
+IEP_DIGIO_DATA_IN_OFFSET        .set    0x0308  ; IEP_DIGIO_DATA_IN register address offset
+IEP_DIGIO_DATA_IN_RAW_OFFSET    .set    0x030C  ; IEP_DIGIO_DATA_IN_RAW register address offset
+IEP_DIGIO_DATA_OUT_OFFSET       .set    0x0310  ; IEP_DIGIO_DATA_OUT register address offset
+IEP_DIGIO_DATA_OUT_EN_OFFSET    .set    0x0314  ; IEP_DIGIO_DATA_OUT_EN register address offset
+IEP_DIGIO_EXP_OFFSET            .set    0x0318  ; IEP_DIGIO_EXP register address offset
+
+; PRU-ICSS IEP register value definitions and constants (selection)
+IEP_TMR_GLB_CFG_RESET           .set    0x0550  ; IEP_TMR_GLB_CFG register reset value
+IEP_TMR_GLB_CFG_CONFIG          .set    0x0111  ; IEP_TMR_GLB_CFG register configuration value
+IEP_TMR_GLB_CFG_CNT_ENABLE_BIT  .set    0       ; IEP_TMR_GLB_CFG CNT_ENABLE bit offset
+IEP_TMR_GLB_STS_CNT_OVF_MASK    .set    0x0001  ; IEP_TMR_GLB_STS CNT_OVF bit mask
+IEP_TMR_COMPEN_RESET            .set    0x0000  ; IEP_TMR_COMPEN register reset value
+IEP_TMR_COMPEN_CONFIG           .set    0x0000  ; IEP_TMR_COMPEN register configuration value
+IEP_TMR_CAP_CFG_RESET           .set    0x0000  ; IEP_TMR_CAP_CFG register reset value
+IEP_TMR_CAP_CFG_CONFIG          .set    0x0000  ; IEP_TMR_CAP_CFG register configuration value
+                                                ; CAPx6 is on pr1_edc_latch0, P9_20, pin mode 6
+                                                ; CAPx7 is on pr1_edc_latch1, P9_19, pin mode 6
+IEP_TMR_CMP_CFG_CAPR6_EN_BIT    .set    6       ; IEP_TMR_CMP_CFG CAPR6_EN bit offset
+IEP_TMR_CMP_CFG_CAPF6_EN_BIT    .set    7       ; IEP_TMR_CMP_CFG CAPF6_EN bit offset
+IEP_TMR_CMP_CFG_CAPR7_EN_BIT    .set    8       ; IEP_TMR_CMP_CFG CAPR7_EN bit offset
+IEP_TMR_CMP_CFG_CAPF7_EN_BIT    .set    9       ; IEP_TMR_CMP_CFG CAPF7_EN bit offset
+IEP_TMR_CMP_STS_CAPR6_VALID_BIT .set    6       ; IEP_TMR_CMP_STS CAPR6_VALID bit offset
+IEP_TMR_CMP_STS_CAPF6_VALID_BIT .set    7       ; IEP_TMR_CMP_STS CAPF6_VALID bit offset
+IEP_TMR_CMP_STS_CAPR7_VALID_BIT .set    8       ; IEP_TMR_CMP_STS CAPR7_VALID bit offset
+IEP_TMR_CMP_STS_CAPF7_VALID_BIT .set    9       ; IEP_TMR_CMP_STS CAPF7_VALID bit offset
 
 
 ; ----------------------------- SPI Definitions ----------------------------- ;
 ; SPI delay cycle definitions
-SPI_SELECT_GUARD_CYCLES     .set    4       ; min. 20ns after CS before SCLK rise
-SPI_DESELECT_GUARD_CYCLES   .set    400     ; min. 4 t_CLK (2us) before CS rise
-SPI_DECODE_GUARD_CYCLES     .set    320     ; min. 4 t_CLK (2us) total burst period
-SPI_IDLE_GUARD_CYCLES       .set    200     ; min. 2 t_CLK (1us) CS high
+SPI_SELECT_GUARD_CYCLES         .set    4       ; min. 20ns after CS before SCLK rise
+SPI_DESELECT_GUARD_CYCLES       .set    400     ; min. 4 t_CLK (2us) before CS rise
+SPI_DECODE_GUARD_CYCLES         .set    320     ; min. 4 t_CLK (2us) total burst period
+SPI_IDLE_GUARD_CYCLES           .set    200     ; min. 2 t_CLK (1us) CS high
 
 
 ; ----------------------------- ADC Definitions ----------------------------- ;
 ; ADC command and delay cycle definitions
-ADC_COMMAND_RESET           .set    0x06    ; reset configuration
-ADC_COMMAND_RDATAC          .set    0x10    ; enable continuous data mode
-ADC_COMMAND_SDATAC          .set    0x11    ; disable continuous data mode
-ADC_COMMAND_RREG            .set    0x20    ; read register data
-ADC_COMMAND_WREG            .set    0x40    ; write register data
-ADC_PRE_RESET_GUARD_CYCLES  .set    200     ; min. 2 t_CLK (1us) before reset
-ADC_RESET_CYCLES            .set    1800    ; min. 18 t_CLK (9us) to perform reset
-ADC_SDATAC_GUARD_CYCLES     .set    400     ; min. 4 t_CLK (2us) to process
+ADC_COMMAND_RESET               .set    0x06    ; reset configuration
+ADC_COMMAND_RDATAC              .set    0x10    ; enable continuous data mode
+ADC_COMMAND_SDATAC              .set    0x11    ; disable continuous data mode
+ADC_COMMAND_RREG                .set    0x20    ; read register data
+ADC_COMMAND_WREG                .set    0x40    ; write register data
+ADC_PRE_RESET_GUARD_CYCLES      .set    200     ; min. 2 t_CLK (1us) before reset
+ADC_RESET_CYCLES                .set    1800    ; min. 18 t_CLK (9us) to perform reset
+ADC_SDATAC_GUARD_CYCLES         .set    400     ; min. 4 t_CLK (2us) to process
 
 ; ADC register addresses and value definitions
-ADC_REGISTER_ID             .set    0x00
-ADC_REGISTER_CONFIG1        .set    0x01
-ADC_REGISTER_CONFIG2        .set    0x02
-ADC_REGISTER_CONFIG3        .set    0x03
-ADC_REGISTER_CH1SET         .set    0x05
-ADC_REGISTER_CH2SET         .set    0x06
-ADC_REGISTER_CH3SET         .set    0x07
-ADC_REGISTER_CH4SET         .set    0x08
-ADC_REGISTER_CH5SET         .set    0x09
-ADC_REGISTER_CH6SET         .set    0x0A
-ADC_REGISTER_CH7SET         .set    0x0B
-ADC_REGISTER_CH8SET         .set    0x0C
+ADC_REGISTER_ID                 .set    0x00
+ADC_REGISTER_CONFIG1            .set    0x01
+ADC_REGISTER_CONFIG2            .set    0x02
+ADC_REGISTER_CONFIG3            .set    0x03
+ADC_REGISTER_CH1SET             .set    0x05
+ADC_REGISTER_CH2SET             .set    0x06
+ADC_REGISTER_CH3SET             .set    0x07
+ADC_REGISTER_CH4SET             .set    0x08
+ADC_REGISTER_CH5SET             .set    0x09
+ADC_REGISTER_CH6SET             .set    0x0A
+ADC_REGISTER_CH7SET             .set    0x0B
+ADC_REGISTER_CH8SET             .set    0x0C
 
 ; ADC register value definitions and constants
-ADC_CONFIG1_VALUE           .set    0x90    ; no daisy-chain, clock out, data rate omitted
-ADC_CONFIG2_VALUE           .set    0xE0    ; reset value of test configuration
-ADC_CONFIG3_VALUE           .set    0xE8    ; 4V reference, internal opamp ref
-ADC_CONFIG1_DR_BASE         .set    0x06    ; base value for DR calcualtion
-ADC_CHANNEL_GAIN1           .set    0x10
-ADC_CHANNEL_GAIN2           .set    0x20
-ADC_PRECISION_LOW_BITS      .set    16      ; data bits for >= 32 kSPS sample rate
-ADC_PRECISION_HIGH_BITS     .set    24      ; data bits for < 32 kSPS sample rate
-ADC_STATUS_BITS             .set    24
-ADC_STATUS_GPIO_MASK        .set    0x0F    ; for all 4 digital inputs
+ADC_CONFIG1_VALUE               .set    0x90    ; no daisy-chain, clock out, data rate omitted
+ADC_CONFIG2_VALUE               .set    0xE0    ; reset value of test configuration
+ADC_CONFIG3_VALUE               .set    0xE8    ; 4V reference, internal opamp ref
+ADC_CONFIG1_DR_BASE             .set    0x06    ; base value for DR calcualtion
+ADC_CHANNEL_GAIN1               .set    0x10
+ADC_CHANNEL_GAIN2               .set    0x20
+ADC_PRECISION_LOW_BITS          .set    16      ; data bits for >= 32 kSPS sample rate
+ADC_PRECISION_HIGH_BITS         .set    24      ; data bits for < 32 kSPS sample rate
+ADC_STATUS_BITS                 .set    24
+ADC_STATUS_GPIO_MASK            .set    0x0F    ; for all 4 digital inputs
 ; --------------------------------------------------------------------------- ;
 
 
@@ -292,6 +366,83 @@ timestamp_restart .macro reg
     LDI     MTMP_REG, PRU_CYCLE_RESET                    ; load reset value
     SBBO    &MTMP_REG, CTRL_ADDRESS, PRU_CYCLE_OFFSET, 4 ; reset counter
     start_counter
+    .endm
+
+
+; ---------------------------- IEP Timer Macros ----------------------------- ;
+; IEP TIMER INIT
+; (initialize the IEP timer in free runing mode with capture compare input)
+iep_timer_init .macro
+    ; set global configuration with enable bit cleared
+    LDI     &MTMP_REG, IEP_TMR_GLB_CFG_CONFIG
+    CLR     &MTMP_REG, IEP_TMR_GLB_CFG_CNT_ENABLE_BIT
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_CFG_OFFSET, 4
+
+    ; reset counter register by writing all bits set
+    ZERO    &MTMP_REG, 4
+    NOT     &MTMP_REG, MTMP_REG
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CNT_OFFSET, 4
+
+    ; clear counter overflow flag
+    LDI     &MTMP_REG, IEP_TMR_GLB_STS_CNT_OVF_MASK
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_STS_OFFSET, 4
+
+    ; set compensation configuration
+    LDI     &MTMP_REG, IEP_TMR_COMPEN_CONFIG
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_COMPEN_OFFSET, 4
+
+    ; set capture configuration
+    LDI     &MTMP_REG, IEP_TMR_CAP_CFG_CONFIG
+    SET     &MTMP_REG, TMP_REG, IEP_TMR_CMP_STS_CAPF6_VALID_BIT
+
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_CFG_OFFSET, 4
+
+    ; clear capture state by register read
+    LBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_STS_OFFSET, 4
+
+    ; set global configuration with enable
+    LDI     &MTMP_REG, IEP_TMR_GLB_CFG_CONFIG
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_CFG_OFFSET, 4
+    .endm
+
+
+; IEP TIMER RESET
+; (stop the IEP timer and reset to default values)
+iep_timer_reset .macro
+    ; reset global timer config to zero to stop initial zero state
+    LDI     &MTMP_REG, IEP_TMR_GLB_CFG_RESET
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_CFG_OFFSET, 4
+
+    ; reset counter register by writing all bits set
+    ZERO    &MTMP_REG, 4
+    NOT     &MTMP_REG, MTMP_REG
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CNT_OFFSET, 4
+
+    ; reset compensation and capture config to initial zero state
+    LDI     &MTMP_REG, IEP_TMR_COMPEN_RESET
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_COMPEN_OFFSET, 4
+    LDI     &MTMP_REG, IEP_TMR_CAP_CFG_RESET
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_CFG_OFFSET, 4
+
+    ; clear overflow flag
+    LDI     &MTMP_REG, IEP_TMR_GLB_STS_CNT_OVF_MASK
+    SBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_GLB_STS_OFFSET, 4
+
+    ; clear capture state by register read
+    LBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_STS_OFFSET, 4
+    .endm
+
+
+; IEP TIMER CAPTURE READ
+; (check for update and read new capture value, sets zero if not captured)
+iep_timer_capture_read .macro
+    ; clear capture value
+    ZERO    &DT_REG, 4
+
+    ; check if new CAPF6 (pr1_edc_latch0, P9_20) value was captured and read if available
+    LBCO    &MTMP_REG, C_PRU_IEP, IEP_TMR_CAP_STS_OFFSET, 4
+    QBBC    RETURN?, MTMP_REG, IEP_TMR_CMP_STS_CAPF6_VALID_BIT
+RETURN?:
     .endm
 
 

--- a/software/rocketlogger/pru/rocketlogger.asm
+++ b/software/rocketlogger/pru/rocketlogger.asm
@@ -1046,6 +1046,9 @@ STOP:
     pwm_stop
     pwm_deinit
 
+    ; stop and deinitialize IEP capture timer
+    iep_timer_deinit
+
     ; clear status LED
     CLR     STATUS_OUT_REG, STATUS_OUT_REG, LED_STATUS_BIT
 

--- a/software/rocketlogger/pru/rocketlogger.asm
+++ b/software/rocketlogger/pru/rocketlogger.asm
@@ -393,7 +393,7 @@ iep_timer_init .macro
 
     ; set capture configuration
     LDI     MTMP_REG, IEP_TMR_CAP_CFG_CONFIG
-    SET     MTMP_REG, MTMP_REG, IEP_TMR_CMP_CFG_CAPF6_EN_BIT
+    SET     MTMP_REG, MTMP_REG, IEP_TMR_CMP_CFG_CAPF7_EN_BIT
     SBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAP_CFG_OFFSET, 4
 
     ; clear capture state by register read
@@ -439,10 +439,10 @@ iep_timer_capture_read .macro
     ; clear capture value
     ZERO    &TIME_REG, 4
 
-    ; check if new CAPF6 (pr1_edc_latch0, P9_20) value was captured and read if available
+    ; check if new CAPF7 (pr1_edc_latch1, P9_19) value was captured and read if available
     LBCO    &MTMP_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAP_STS_OFFSET, 4
-    QBBC    RETURN?, MTMP_REG, IEP_TMR_CMP_STS_CAPF6_VALID_BIT
-    LBCO    &TIME_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAPF6_OFFSET, 4
+    QBBC    RETURN?, MTMP_REG, IEP_TMR_CMP_STS_CAPF7_VALID_BIT
+    LBCO    &TIME_REG, PRU_ICSS_IEP_BASE_CONST, IEP_TMR_CAPF7_OFFSET, 4
 RETURN?:
     .endm
 


### PR DESCRIPTION
Introduce hardware based timestamping of time between two ADC samples (i.e. the DT channel) based on the PRU IEP timer capture functionality.

* introduce PRU IEP timer capture configuration code for hardware based timestamping the time between two ADC samples
* remove use of PRU cycle counter for time delta measurement between two ADC samples
* use fixed channel calibration values (obsoletes use of DT channel calibration data)

:warning: Requires hardware modification to work: connect the ADC data ready signal to the `edc_latch1_in` input, e.g. by wiring extension header pin `P8.15` or `P8.16` to pin `P9.19`

For an alternative hardware timestamping using eCAP capture module see #67.