### PR TITLE
Hardware based timestamping using PRU eCAP capture

### DIFF
--- a/software/rocketlogger/calibration.c
+++ b/software/rocketlogger/calibration.c
@@ -108,6 +108,10 @@ int calibration_load(void) {
 
     memcpy(&rl_calibration, &(calibration_file.data), sizeof(rl_calibration_t));
 
+    // PRU DT channel has implementation specific, fixed conversion
+    rl_calibration.offsets[RL_CONFIG_CHANNEL_DT] = 0;
+    rl_calibration.scales[RL_CONFIG_CHANNEL_DT] = 5;
+
     // store calibration info information to status
     rl_status.calibration_time = calibration_file.calibration_time;
     strncpy(rl_status.calibration_file, calibration_file_name,

--- a/software/rocketlogger/overlay/ROCKETLOGGER.dts
+++ b/software/rocketlogger/overlay/ROCKETLOGGER.dts
@@ -99,8 +99,8 @@
       P9_29_pinmux { status = "disabled"; }; /* MOSI pin, PRU0 controlled */
       P9_30_pinmux { status = "disabled"; }; /* MISO0 pin, PRU0 controlled */
       P9_31_pinmux { status = "disabled"; }; /* SCLK pin, PRU0 controlled */
-      P8_15_pinmux { status = "disabled"; }; /* DR1 pin, PRU0 controlled */
-      P8_16_pinmux { status = "disabled"; }; /* DR0 pin, PRU0 controlled */
+      P8_15_pinmux { status = "disabled"; }; /* nDR0 pin, MUX_MODE6 for PRU0 controlled, MUX_MODE5 for pr1_ecap0_ecap_capin_apwm_o */
+      P8_16_pinmux { status = "disabled"; }; /* nDR1 pin, PRU0 controlled */
       P9_11_pinmux { status = "disabled"; }; /* nForce high range 1 pin */
       P9_12_pinmux { status = "disabled"; }; /* nForce high range 2 pin */
       P8_11_pinmux { status = "disabled"; }; /* Status LED pin, MUX_MODE7 for GPIO, MUX_MODE6 for PRU0 controlled */
@@ -143,8 +143,8 @@
           BONE_P9_29 (PIN_OUTPUT_PULLDOWN | MUX_MODE5) /* MOSI pin, PRU0 controlled */
           BONE_P9_30 (PIN_INPUT_PULLDOWN | MUX_MODE6) /* MISO0 pin, PRU0 controlled */
           BONE_P9_31 (PIN_OUTPUT_PULLDOWN | MUX_MODE5) /* SCLK pin, PRU0 controlled */
-          BONE_P8_15 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR1 pin, PRU0 controlled */
-          BONE_P8_16 (PIN_INPUT_PULLUP | MUX_MODE6) /* DR0 pin, PRU0 controlled */
+          BONE_P8_15 (PIN_INPUT_PULLUP | MUX_MODE5) /* nDR0 pin, MUX_MODE6 for PRU0 controlled, MUX_MODE5 for pr1_ecap0_ecap_capin_apwm_o */
+          BONE_P8_16 (PIN_INPUT_PULLUP | MUX_MODE6) /* nDR1 pin, PRU0 controlled */
         >;
       };
 

--- a/software/rocketlogger/pru/rocketlogger.asm
+++ b/software/rocketlogger/pru/rocketlogger.asm
@@ -794,7 +794,7 @@ READ:
     SET     STATUS_OUT_REG, STATUS_OUT_REG, LED_STATUS_BIT
 
     ; wait for data ready
-    WBC     ADC_IN_REG, DR1_BIT
+    WBC     ADC_IN_REG, DR2_BIT
 
     ; immediately timestamp data
     timestamp_restart DT_REG

--- a/software/rocketlogger/pru/rocketlogger.asm
+++ b/software/rocketlogger/pru/rocketlogger.asm
@@ -207,6 +207,24 @@ PWM_RANGE_RESET_PERIOD_BASE .set    (50000 + 5000)  ; Range latch base period, 0
 PWM_RANGE_RESET_PULSE_WIDTH .set    50              ; Range latch reset pulse width (in units of 10 ns)
 
 
+; ------------------------ PRU-ICSS eCAP Definitions ------------------------- ;
+; PRU-ICSS eCAP module and configuration register offsets
+PRU_ICSS_ECAP_BASE_CONST    .set    C_PRU_ECAP
+ECAP_TSCTR_OFFSET           .set    0x0000  ; ECAP_TSCTR register address offset
+ECAP_CTRPHS_OFFSET          .set    0x0004  ; ECAP_CTRPHS register address offset
+ECAP_CAP1_OFFSET            .set    0x0008  ; ECAP_CAP1 register address offset
+ECAP_CAP2_OFFSET            .set    0x000C  ; ECAP_CAP2 register address offset
+ECAP_CAP3_OFFSET            .set    0x0010  ; ECAP_CAP3 register address offset
+ECAP_CAP4_OFFSET            .set    0x0014  ; ECAP_CAP4 register address offset
+ECAP_ECCTL1_OFFSET          .set    0x0028  ; ECAP_ECCTL1 register address offset
+ECAP_ECCTL2_OFFSET          .set    0x002A  ; ECAP_ECCTL2 register address offset
+ECAP_ECEINT_OFFSET          .set    0x002C  ; ECAP_ECEINT register address offset
+ECAP_ECFLG_OFFSET           .set    0x002E  ; ECAP_ECFLG register address offset
+ECAP_ECCLR_OFFSET           .set    0x0030  ; ECAP_ECCLR register address offset
+ECAP_ECFRC_OFFSET           .set    0x0032  ; ECAP_ECFRC register address offset
+ECAP_REVID_OFFSET           .set    0x005C  ; ECAP_REVID register address offset
+
+
 ; ----------------------------- SPI Definitions ----------------------------- ;
 ; SPI delay cycle definitions
 SPI_SELECT_GUARD_CYCLES     .set    4       ; min. 20ns after CS before SCLK rise

--- a/software/rocketlogger/pru/rocketlogger.asm
+++ b/software/rocketlogger/pru/rocketlogger.asm
@@ -100,7 +100,7 @@ I1L_REG                     .set    r5
 I1H_REG                     .set    r6
 I2L_REG                     .set    r7
 I2H_REG                     .set    r8
-TIME_REG                    .set    r9      ; timer capture on ADC ready
+DT_REG                      .set    r9      ; delta capture on ADC ready
 
 ; PRU register definitions: double sampled channel data from ADC
 I1L_2_REG                   .set    r10
@@ -226,7 +226,7 @@ ECAP_REVID_OFFSET           .set    0x005C  ; ECAP_REVID register address offset
 
 ; PRU-ICSS eCAP register value definitions and constants (selection)
 ECAP_ECCTL1_RESET           .set    0x0000  ; ECAP_ECCTL1 register reset value
-ECAP_ECCTL1_CONFIG          .set    0x0101  ; ECAP_ECCTL1 register configuration value
+ECAP_ECCTL1_CONFIG          .set    0x0103  ; ECAP_ECCTL1 register configuration value
 ECAP_ECCTL1_CAP1POL_BIT     .set    0       ; ECAP_ECCTL1 CAP1POL bit offset
 ECAP_ECCTL1_CTRRST1_BIT     .set    1       ; ECAP_ECCTL1 CTRRST1 bit offset
 ECAP_ECCTL1_CAP2POL_BIT     .set    2       ; ECAP_ECCTL1 CAP2POL bit offset
@@ -400,12 +400,14 @@ ecap_deinit .macro
 ; (check for update and read new capture value, sets zero if not captured)
 ecap_capture_read .macro
     ; clear result value
-    ZERO    &TIME_REG, 4
+    ZERO    &DT_REG, 4
 
-    ; check if new CAP1 (pr1_ecap0_ecap_capin_apwm_o, P8_15) value was captured and read if available
+    ; check if new CAP1 (pr1_ecap0_ecap_capin_apwm_o, P8_15) was captured
     LBCO    &MTMP_REG, PRU_ICSS_ECAP_BASE_CONST, ECAP_ECFLG_OFFSET, 2
     QBBC    RETURN?, MTMP_REG, ECAP_INT_CEVT1_BIT
-    LBCO    &TIME_REG, PRU_ICSS_ECAP_BASE_CONST, ECAP_CAP1_OFFSET, 4
+    ; read capture value and increment by 1 for the extra zero reset cycle
+    LBCO    &DT_REG, PRU_ICSS_ECAP_BASE_CONST, ECAP_CAP1_OFFSET, 4
+    ADD     DT_REG, DT_REG, 1
 RETURN?:
     .endm
 


### PR DESCRIPTION
Introduce hardware based timestamping of time between two ADC samples (i.e. the DT channel) based on the PRU eCAP functionality.

* add PRU eCAP0 capture configuration code for hardware based timestamping the time between two ADC samples
* fix naming of GPIO inputs `DR0`/`DR1` to `nDR0`/`nDR1` in devicetree to reflect their active low signal semantic
* change PRU to wait for new ADC data from `nDR0` to `nDR1` signal
* remap `nDR0` signal for use as capture input with eCAP0 module
* use fixed channel calibration values (obsoletes use of DT channel calibration data)
* remove use of PRU cycle counter for time delta measurement between two ADC samples
