### PR TITLE
Activity accurate down-sampling and plotting of binary channels

### DIFF
--- a/software/node_server/buffer.js
+++ b/software/node_server/buffer.js
@@ -40,8 +40,8 @@ class AggregatingBuffer {
     // enqueue aggregates of a typed array at end of typed array buffer
     static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
         buffer_out.set(buffer_out.subarray(count));
-        for (let i = 0; i < count; i++) {
-            buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
+        for (let i = buffer_out.length - count, offset_in = 0; i < buffer_out.length; i++, offset_in += aggregation_factor) {
+            buffer_out[i] = buffer_in[offset_in];
         }
     }
 }
@@ -68,9 +68,8 @@ class AggregatingDataStore extends AggregatingBuffer {
             // insert data limited to non-full buffer level
             const insert_size = Math.min(index_start, data.length);
             this._dataLevel[i].set(data.subarray(data.length - insert_size), index_start - insert_size);
-            return;
+            break;
         }
-        console.warn('failed inserting cached data into buffer');
     }
 
     getValidView() {
@@ -95,12 +94,15 @@ class AggregatingBinaryStore extends AggregatingBuffer {
 
     static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
         buffer_out.set(buffer_out.subarray(count));
-        buffer_out.fill(0x00ff, -count);
-        for (let i = 0; i < count; i++) {
-            for (let j = 1; j < aggregation_factor; j++) {
-                buffer_out[buffer_out.length - count + i] &= 0xff00 | buffer_in[i * aggregation_factor + j];
-                buffer_out[buffer_out.length - count + i] |= 0xff00 & buffer_in[i * aggregation_factor + j];
+        for (let i = buffer_out.length - count, offset_in = 0; i < buffer_out.length; i++) {
+            let min = 0x00ff;
+            let max = 0x00ff;
+            for (let j = 0; j < aggregation_factor; j++, offset_in++) {
+                const value = buffer_in[offset_in];
+                min &= value;
+                max |= value;
             }
+            buffer_out[i] = max & (0xff00 | min);
         }
     }
 
@@ -120,13 +122,15 @@ class AggregatingBinaryStore extends AggregatingBuffer {
 class MaxAggregatingDataStore extends AggregatingDataStore {
     static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
         buffer_out.set(buffer_out.subarray(count));
-        for (let i = 0; i < count; i++) {
-            buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
-            for (let j = 1; j < aggregation_factor; j++) {
-                if (buffer_out[buffer_out.length - count + i] < buffer_in[i * aggregation_factor + j]) {
-                    buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor + j];
+        for (let i = buffer_out.length - count, offset_in = 0; i < buffer_out.length; i++) {
+            let max = buffer_in[offset_in++];
+            for (let j = 1; j < aggregation_factor; j++, offset_in++) {
+                const value = buffer_in[offset_in];
+                if (max < value) {
+                    max = value;
                 }
             }
+            buffer_out[i] = max;
         }
     }
 }
@@ -134,13 +138,15 @@ class MaxAggregatingDataStore extends AggregatingDataStore {
 class MinAggregatingDataStore extends AggregatingDataStore {
     static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
         buffer_out.set(buffer_out.subarray(count));
-        for (let i = 0; i < count; i++) {
-            buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
-            for (let j = 1; j < aggregation_factor; j++) {
-                if (buffer_out[buffer_out.length - count + i] > buffer_in[i * aggregation_factor + j]) {
-                    buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor + j];
+        for (let i = buffer_out.length - count, offset_in = 0; i < buffer_out.length; i++) {
+            let min = buffer_in[offset_in++];
+            for (let j = 1; j < aggregation_factor; j++, offset_in++) {
+                const value = buffer_in[offset_in];
+                if (min > value) {
+                    min = value;
                 }
             }
+            buffer_out[i] = min;
         }
     }
 }

--- a/software/node_server/buffer.js
+++ b/software/node_server/buffer.js
@@ -5,6 +5,9 @@ export { AggregatingBuffer };
 
 class AggregatingBuffer {
     constructor(TypedArrayT, size, levels, aggregation_factor, initial_value = 0) {
+        if (!TypedArrayT.hasOwnProperty('BYTES_PER_ELEMENT')) {
+            throw TypeError('supporting TypedArray types only');
+        }
         this._size = size;
         this._levels = levels;
         this._aggregation_factor = aggregation_factor;

--- a/software/node_server/buffer.js
+++ b/software/node_server/buffer.js
@@ -14,17 +14,14 @@ class AggregatingBuffer {
     }
 
     add(data) {
-        for (let i = 1; i <= this._levels; i++) {
-            if (i == this._levels) {
-                // enqueue new data
-                typedarray_enqueue(data, this._dataLevel[i - 1]);
-                break;
-            }
-
-            // aggregate data about to be dequeued to next lower buffer
+        // aggregate data about to be dequeued to next lower buffer
+        for (let i = 1; i < this._levels; i++) {
             const aggregate_count = data.length / (this._aggregation_factor ** (this._levels - i));
             typedarray_enqueue_aggregate(this._dataLevel[i], this._dataLevel[i - 1], aggregate_count, this._aggregation_factor);
         }
+
+        // enqueue new data
+        typedarray_enqueue(data, this._dataLevel[this._levels - 1]);
     }
 
     getView() {
@@ -41,12 +38,7 @@ function typedarray_enqueue(buffer_in, buffer_out) {
 // enqueue aggregates of a typed array at end of typed array buffer
 function typedarray_enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
     buffer_out.set(buffer_out.subarray(count));
-    aggregate(buffer_out.subarray(buffer_out.length - count), buffer_in, aggregation_factor);
-}
-
-// typed array to typed array sample aggregation
-function aggregate(buffer_out, buffer_in, factor) {
-    for (let i = 0; i < buffer_out.length; i++) {
-        buffer_out[i] = buffer_in[i * factor];
+    for (let i = 0; i < count; i++) {
+        buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
     }
 }

--- a/software/node_server/buffer.js
+++ b/software/node_server/buffer.js
@@ -1,6 +1,6 @@
 "use strict";
 
-export { AggregatingBuffer, AggregatingDataStore };
+export { AggregatingBuffer, AggregatingDataStore, MaxAggregatingDataStore, MinAggregatingDataStore };
 
 
 class AggregatingBuffer {
@@ -80,5 +80,25 @@ class AggregatingDataStore extends AggregatingBuffer {
 
     _get_start_index() {
         return this._start_index = this._data.findLastIndex(isNaN, this._start_index) + 1;
+    }
+}
+
+class MaxAggregatingDataStore extends AggregatingDataStore {
+    static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
+        buffer_out.set(buffer_out.subarray(count));
+        const nanMaxReduce = (a, v) => isNaN(a) || v > a ? v : a;
+        for (let i = 0; i < count; i++) {
+            buffer_out[buffer_out.length - count + i] = buffer_in.subarray(i * aggregation_factor, (i + 1) * aggregation_factor).reduce(nanMaxReduce, NaN);
+        }
+    }
+}
+
+class MinAggregatingDataStore extends AggregatingDataStore {
+    static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
+        buffer_out.set(buffer_out.subarray(count));
+        const nanMinReduce = (a, v) => isNaN(a) || v < a ? v : a;
+        for (let i = 0; i < count; i++) {
+            buffer_out[buffer_out.length - count + i] = buffer_in.subarray(i * aggregation_factor, (i + 1) * aggregation_factor).reduce(nanMinReduce, NaN);
+        }
     }
 }

--- a/software/node_server/buffer.js
+++ b/software/node_server/buffer.js
@@ -86,9 +86,13 @@ class AggregatingDataStore extends AggregatingBuffer {
 class MaxAggregatingDataStore extends AggregatingDataStore {
     static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
         buffer_out.set(buffer_out.subarray(count));
-        const nanMaxReduce = (a, v) => isNaN(a) || v > a ? v : a;
         for (let i = 0; i < count; i++) {
-            buffer_out[buffer_out.length - count + i] = buffer_in.subarray(i * aggregation_factor, (i + 1) * aggregation_factor).reduce(nanMaxReduce, NaN);
+            buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
+            for (let j = 1; j < aggregation_factor; j++) {
+                if (buffer_out[buffer_out.length - count + i] < buffer_in[i * aggregation_factor + j]) {
+                    buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor + j];
+                }
+            }
         }
     }
 }
@@ -96,9 +100,13 @@ class MaxAggregatingDataStore extends AggregatingDataStore {
 class MinAggregatingDataStore extends AggregatingDataStore {
     static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
         buffer_out.set(buffer_out.subarray(count));
-        const nanMinReduce = (a, v) => isNaN(a) || v < a ? v : a;
         for (let i = 0; i < count; i++) {
-            buffer_out[buffer_out.length - count + i] = buffer_in.subarray(i * aggregation_factor, (i + 1) * aggregation_factor).reduce(nanMinReduce, NaN);
+            buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
+            for (let j = 1; j < aggregation_factor; j++) {
+                if (buffer_out[buffer_out.length - count + i] > buffer_in[i * aggregation_factor + j]) {
+                    buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor + j];
+                }
+            }
         }
     }
 }

--- a/software/node_server/buffer.js
+++ b/software/node_server/buffer.js
@@ -20,28 +20,28 @@ class AggregatingBuffer {
         // aggregate data about to be dequeued to next lower buffer
         for (let i = 1; i < this._levels; i++) {
             const aggregate_count = data.length / (this._aggregation_factor ** (this._levels - i));
-            typedarray_enqueue_aggregate(this._dataLevel[i], this._dataLevel[i - 1], aggregate_count, this._aggregation_factor);
+            this.constructor._enqueue_aggregate(this._dataLevel[i], this._dataLevel[i - 1], aggregate_count, this._aggregation_factor);
         }
 
         // enqueue new data
-        typedarray_enqueue(data, this._dataLevel[this._levels - 1]);
+        this.constructor._enqueue(data, this._dataLevel[this._levels - 1]);
     }
 
     getView() {
         return this._data;
     }
-}
 
-// enqueue typed array data at end of typed array buffer
-function typedarray_enqueue(buffer_in, buffer_out) {
-    buffer_out.set(buffer_out.subarray(buffer_in.length));
-    buffer_out.set(buffer_in, buffer_out.length - buffer_in.length);
-}
+    // enqueue typed array data at end of typed array buffer
+    static _enqueue(buffer_in, buffer_out) {
+        buffer_out.set(buffer_out.subarray(buffer_in.length));
+        buffer_out.set(buffer_in, buffer_out.length - buffer_in.length);
+    }
 
-// enqueue aggregates of a typed array at end of typed array buffer
-function typedarray_enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
-    buffer_out.set(buffer_out.subarray(count));
-    for (let i = 0; i < count; i++) {
-        buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
+    // enqueue aggregates of a typed array at end of typed array buffer
+    static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
+        buffer_out.set(buffer_out.subarray(count));
+        for (let i = 0; i < count; i++) {
+            buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
+        }
     }
 }

--- a/software/node_server/rl.cache.js
+++ b/software/node_server/rl.cache.js
@@ -20,7 +20,7 @@ class DataCache {
     // reset data cache by re-initializing buffers for existing
     reset() {
         this._time = new AggregatingBuffer(Float64Array, this._size, this._levels, this._aggregation_factor, NaN);
-        this._digital = new AggregatingBuffer(Uint8Array, this._size, this._levels, this._aggregation_factor);
+        this._digital = new AggregatingBuffer(Uint16Array, this._size, this._levels, this._aggregation_factor);
         this._data = {};
         for (const ch in this._metadata) {
             if (this._metadata[ch].unit !== 'binary') {

--- a/software/node_server/rl.cache.js
+++ b/software/node_server/rl.cache.js
@@ -2,7 +2,7 @@
 
 // imports
 import debug from 'debug';
-import { AggregatingBuffer } from './buffer.js';
+import { AggregatingDataStore, AggregatingBinaryStore } from './buffer.js';
 
 export { DataCache };
 
@@ -19,12 +19,12 @@ class DataCache {
 
     // reset data cache by re-initializing buffers for existing
     reset() {
-        this._time = new AggregatingBuffer(Float64Array, this._size, this._levels, this._aggregation_factor, NaN);
-        this._digital = new AggregatingBuffer(Uint16Array, this._size, this._levels, this._aggregation_factor);
+        this._time = new AggregatingDataStore(Float64Array, this._size, this._levels, this._aggregation_factor);
+        this._digital = new AggregatingBinaryStore(Uint16Array, this._size, this._levels, this._aggregation_factor);
         this._data = {};
         for (const ch in this._metadata) {
             if (this._metadata[ch].unit !== 'binary') {
-                this._data[ch] = new AggregatingBuffer(Float32Array, this._size, this._levels, this._aggregation_factor);
+                this._data[ch] = new AggregatingDataStore(Float32Array, this._size, this._levels, this._aggregation_factor);
             }
         }
     }

--- a/software/node_server/rl.data.js
+++ b/software/node_server/rl.data.js
@@ -133,10 +133,15 @@ function parse_digital_data(header, data) {
     const data_in_view = new Uint32Array(data.buffer);
     const data_out_length = data_in_view.length / header.downsample_factor;
 
-    const data_out = new Uint8Array(data_out_length);
+    const data_out = new Uint16Array(data_out_length);
+    const data_out_view = new Uint8Array(data_out.buffer);
     for (let j = 0; j < Math.min(data_out_length, data_in_view.length / header.downsample_factor); j++) {
-        data_out[j] = data_in_view[j * header.downsample_factor];
-        /// @todo any/none down sampling
+        data_out_view[2 * j] = data_in_view[j * header.downsample_factor];
+        data_out_view[2 * j + 1] = data_in_view[j * header.downsample_factor];
+        for (let k = 1; k < header.downsample_factor; k++) {
+            data_out_view[2 * j] &= data_in_view[j * header.downsample_factor + k];
+            data_out_view[2 * j + 1] |= data_in_view[j * header.downsample_factor + k];
+        }
     }
 
     return data_out;

--- a/software/node_server/static/js/rl.data.js
+++ b/software/node_server/static/js/rl.data.js
@@ -527,6 +527,9 @@ function data_add(message, cache_data = false) {
 
 class AggregatingBuffer {
     constructor(TypedArrayT, size, levels, aggregation_factor, initial_value = 0) {
+        if (!TypedArrayT.hasOwnProperty('BYTES_PER_ELEMENT')) {
+            throw TypeError('supporting TypedArray types only');
+        }
         this._size = size;
         this._levels = levels;
         this._aggregation_factor = aggregation_factor;
@@ -539,15 +542,29 @@ class AggregatingBuffer {
         // aggregate data about to be dequeued to next lower buffer
         for (let i = 1; i < this._levels; i++) {
             const aggregate_count = data.length / (this._aggregation_factor ** (this._levels - i));
-            typedarray_enqueue_aggregate(this._dataLevel[i], this._dataLevel[i - 1], aggregate_count, this._aggregation_factor);
+            this.constructor._enqueue_aggregate(this._dataLevel[i], this._dataLevel[i - 1], aggregate_count, this._aggregation_factor);
         }
 
         // enqueue new data
-        typedarray_enqueue(data, this._dataLevel[this._levels - 1]);
+        this.constructor._enqueue(data, this._dataLevel[this._levels - 1]);
     }
 
     getView() {
         return this._data;
+    }
+
+    // enqueue typed array data at end of typed array buffer
+    static _enqueue(buffer_in, buffer_out) {
+        buffer_out.set(buffer_out.subarray(buffer_in.length));
+        buffer_out.set(buffer_in, buffer_out.length - buffer_in.length);
+    }
+
+    // enqueue aggregates of a typed array at end of typed array buffer
+    static _enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
+        buffer_out.set(buffer_out.subarray(count));
+        for (let i = 0; i < count; i++) {
+            buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
+        }
     }
 }
 
@@ -585,20 +602,5 @@ class AggregatingDataStore extends AggregatingBuffer {
 
     _get_start_index() {
         return this._start_index = this._data.findLastIndex(isNaN, this._start_index) + 1;
-    }
-}
-
-
-// enqueue typed array data at end of typed array buffer
-function typedarray_enqueue(buffer_in, buffer_out) {
-    buffer_out.set(buffer_out.subarray(buffer_in.length));
-    buffer_out.set(buffer_in, buffer_out.length - buffer_in.length);
-}
-
-// enqueue aggregates of a typed array at end of typed array buffer
-function typedarray_enqueue_aggregate(buffer_in, buffer_out, count, aggregation_factor) {
-    buffer_out.set(buffer_out.subarray(count));
-    for (let i = 0; i < count; i++) {
-        buffer_out[buffer_out.length - count + i] = buffer_in[i * aggregation_factor];
     }
 }

--- a/software/node_server/static/js/rl.data.js
+++ b/software/node_server/static/js/rl.data.js
@@ -309,7 +309,7 @@ function plot_get_ylayout(plot_config) {
     if (plot_config.unit === 'binary') {
         yaxis.autorange = false;
         yaxis.range = [-0.15, 5.85];
-        yaxis.tickvals = [0, 0.7, 1, 1.7, 2, 2.7, 3, 3.7, 4, 4.7, 5, 5.7];
+        yaxis.tickvals = [0, 0.66, 1, 1.66, 2, 2.66, 3, 3.66, 4, 4.66, 5, 5.66];
         yaxis.ticktext = ['LO', 'HI', 'LO', 'HI', 'LO', 'HI', 'LO', 'HI', 'LO', 'HI', 'LO', 'HI'];
         yaxis.zeroline = false;
     }
@@ -462,8 +462,10 @@ function data_add(message, cache_data = false) {
     for (const ch in rl._data.metadata) {
         if (rl._data.metadata[ch].unit === 'binary') {
             const bit_offset = rl._data.metadata[ch].bit;
-            const data_digital = Float32Array.from(new Uint8Array(message.digital),
-                value => bit_offset + (value & (0x01 << bit_offset) ? 0.7 : 0));
+            const data_digital = Float32Array.from(new Uint16Array(message.digital),
+                value => bit_offset +
+                    ((value & (0x0001 << bit_offset)) ? 0.33 : 0) +
+                    ((value & (0x0100 << bit_offset)) ? 0.33 : 0));
             insert(rl._data.buffer[ch], data_digital);
         } else {
             const data_view = new Float32Array(message.data[ch]);

--- a/software/node_server/tests/buffer.test.js
+++ b/software/node_server/tests/buffer.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { AggregatingBuffer } from '../buffer.js';
+import { AggregatingBuffer, AggregatingDataStore } from '../buffer.js';
 
 
 describe('AggregatingBuffer class', () => {
@@ -71,36 +71,189 @@ describe('AggregatingBuffer class', () => {
             buffer._data.forEach((_, i, arr) => { arr[i] = i; });
         });
 
-        test('before add()', () => {
+        test('initial state', () => {
             const data_view = buffer.getView();
-            expect(data_view[0]).toBe(0);
-            expect(data_view[73]).toBe(73);
-            expect(data_view[data_view.length - 31]).toBe(data_view.length - 31);
-            expect(data_view[data_view.length - 1]).toBe(data_view.length - 1);
+            expect(data_view.at(0)).toBe(0);
+            expect(data_view.at(73)).toBe(73);
+            expect(data_view.at(-31)).toBe(data_view.length - 31);
+            expect(data_view.at(-1)).toBe(data_view.length - 1);
         });
 
-        test('after add()', () => {
+        test('add() once', () => {
             const data_to_add = new Float32Array(100).fill(NaN);
             buffer.add(data_to_add);
 
             const data_view = buffer.getView();
             // 1st buffer
-            expect(data_view[0]).toBe(1);
-            expect(data_view[1]).toBe(2);
-            expect(data_view[999]).toBe(1000);
+            expect(data_view.at(0)).toBe(1);
+            expect(data_view.at(1)).toBe(2);
+            expect(data_view.at(999)).toBe(1000);
             // 2nd buffer
-            expect(data_view[1000]).toBe(1010);
-            expect(data_view[1001]).toBe(1011);
-            expect(data_view[1989]).toBe(1999);
-            expect(data_view[1990]).toBe(2000);
-            expect(data_view[1999]).toBe(2090);
+            expect(data_view.at(1000)).toBe(1010);
+            expect(data_view.at(1001)).toBe(1011);
+            expect(data_view.at(1989)).toBe(1999);
+            expect(data_view.at(1990)).toBe(2000);
+            expect(data_view.at(1999)).toBe(2090);
             // 3rd buffer
-            expect(data_view[2000]).toBe(2100);
-            expect(data_view[2001]).toBe(2101);
-            expect(data_view[data_view.length - data_to_add.length - 13]).toBe(data_view.length - 13);
-            expect(data_view[data_view.length - data_to_add.length - 1]).toBe(data_view.length - 1);
-            expect(data_view[data_view.length - data_to_add.length]).toBe(NaN);
-            expect(data_view[data_view.length - 1]).toBe(NaN);
+            expect(data_view.at(2000)).toBe(2100);
+            expect(data_view.at(2001)).toBe(2101);
+            expect(data_view.at(-data_to_add.length - 13)).toBe(data_view.length - 13);
+            expect(data_view.at(-data_to_add.length - 1)).toBe(data_view.length - 1);
+            expect(data_view.at(-data_to_add.length)).toBe(data_to_add.at(0));
+            expect(data_view.at(-1)).toBe(data_to_add.at(-1));
+        });
+    });
+});
+
+describe('AggregatingDataStore class', () => {
+    describe('construction', () => {
+        test('Float32Array', () => {
+            const buffer = new AggregatingDataStore(Float32Array, 1000, 3, 10);
+
+            const data_view = buffer.getView();
+            expect(data_view.every(isNaN)).toBeTruthy();
+        });
+
+        test('Float64Array', () => {
+            const buffer = new AggregatingDataStore(Float64Array, 1000, 3, 10);
+
+            const data_view = buffer.getView();
+            expect(data_view.every(isNaN)).toBeTruthy();
+        });
+
+        test('Int8Array', () => {
+            const int8ArrayAggregatingBuffer = () => {
+                new AggregatingDataStore(Int8Array, 1000, 3, 10);
+            };
+            expect(int8ArrayAggregatingBuffer).toThrow(TypeError);
+        });
+
+        test('Uint32Array', () => {
+            const uint32ArrayAggregatingBuffer = () => {
+                new AggregatingDataStore(Uint32Array, 1000, 3, 10);
+            };
+            expect(uint32ArrayAggregatingBuffer).toThrow(TypeError);
+        });
+
+        test('String', () => {
+            const stringAggregatingBuffer = () => {
+                new AggregatingDataStore(String, 1000, 3, 10);
+            };
+            expect(stringAggregatingBuffer).toThrow(TypeError);
+        });
+
+        test('ArrayBuffer', () => {
+            const arrayBufferAggregatingBuffer = () => {
+                new AggregatingDataStore(ArrayBuffer, 1000, 3, 10);
+            };
+            expect(arrayBufferAggregatingBuffer).toThrow(TypeError);
+        });
+    });
+
+    describe('buffer values', () => {
+        let buffer;
+        beforeEach(() => {
+            buffer = new AggregatingDataStore(Float32Array, 1000, 3, 10);
+        });
+
+        test('initial state', () => {
+            expect(buffer._get_start_index()).toBe(buffer._data.length);
+
+            const data_valid_view = buffer.getValidView();
+            expect(data_valid_view.length).toBe(0);
+
+            const data_view = buffer.getView();
+            expect(data_view.at(0)).toBeNaN();
+            expect(data_view.at(73)).toBeNaN();
+            expect(data_view.at(-31)).toBeNaN();
+            expect(data_view.at(-1)).toBeNaN();
+        });
+
+        test('add() once', () => {
+            const data_to_add = Float32Array.from({ length: 100 }, (_, i) => i);
+            buffer.add(data_to_add);
+
+            const data_valid_view = buffer.getValidView();
+            expect(data_valid_view.length).toBe(data_to_add.length);
+
+            const data_view = buffer.getView();
+            expect(data_view.at(-buffer._size - 13)).toBeNaN();
+            expect(data_view.at(-buffer._size - 1)).toBeNaN();
+            expect(data_view.at(-data_to_add.length - 13)).toBeNaN();
+            expect(data_view.at(-data_to_add.length - 1)).toBeNaN();
+            expect(data_view.at(-data_to_add.length)).toBe(data_to_add.at(0));
+            expect(data_view.at(-1)).toBe(data_to_add.at(-1));
+        });
+
+        test('prepend() once', () => {
+            const data_to_prepend = Float32Array.from({ length: 100 }, (_, i) => -100 + i);
+            buffer.prepend(data_to_prepend);
+
+            const data_valid_view = buffer.getValidView();
+            expect(data_valid_view.length).toBe(data_to_prepend.length);
+
+            const data_view = buffer.getView();
+            expect(data_view.at(-data_to_prepend.length - 13)).toBeNaN();
+            expect(data_view.at(-data_to_prepend.length - 1)).toBeNaN();
+            expect(data_view.at(-data_to_prepend.length)).toBe(data_to_prepend.at(0));
+            expect(data_view.at(-1)).toBe(data_to_prepend.at(-1));
+        });
+
+        test('add() once, prepend() once', () => {
+            const data_to_add = Float32Array.from({ length: 100 }, (_, i) => i);
+            const data_to_prepend = Float32Array.from({ length: 100 }, (_, i) => -100 + i);
+            buffer.add(data_to_add);
+            buffer.prepend(data_to_prepend);
+
+            const data_valid_view = buffer.getValidView();
+            expect(data_valid_view.length).toBe(data_to_add.length + data_to_prepend.length);
+
+            const data_view = buffer.getView();
+            expect(data_view.at(-data_to_add.length - data_to_prepend.length - 13)).toBeNaN();
+            expect(data_view.at(-data_to_add.length - data_to_prepend.length - 1)).toBeNaN();
+            expect(data_view.at(-data_to_add.length - data_to_prepend.length)).toBe(data_to_prepend.at(0));
+            expect(data_view.at(-data_to_add.length - 1)).toBe(data_to_prepend.at(-1));
+            expect(data_view.at(-data_to_add.length)).toBe(data_to_add.at(0));
+            expect(data_view.at(-1)).toBe(data_to_add.at(-1));
+        });
+
+        test('add() once, prepend() excessive data', () => {
+            const data_to_add = Float32Array.from({ length: 100 }, (_, i) => i);
+            const data_to_prepend = Float32Array.from({ length: 1000 }, (_, i) => -1000 + i);
+            buffer.add(data_to_add);
+            buffer.prepend(data_to_prepend);
+
+            const data_valid_view = buffer.getValidView();
+            expect(data_valid_view.length).toBe(buffer._size);
+
+            const data_view = buffer.getView();
+            expect(data_view.at(-buffer._size - 13)).toBeNaN();
+            expect(data_view.at(-buffer._size - 1)).toBeNaN();
+            expect(data_view.at(-buffer._size)).toBe(data_to_prepend.at(data_to_add.length - buffer._size));
+            expect(data_view.at(-data_to_add.length - 1)).toBe(data_to_prepend.at(-1));
+            expect(data_view.at(-data_to_add.length)).toBe(data_to_add.at(0));
+            expect(data_view.at(-1)).toBe(data_to_add.at(-1));
+        });
+
+        test('prepend() full, add() with aggregate', () => {
+            const data_to_prepend = Float32Array.from({ length: 1000 }, (_, i) => i);
+            const data_to_add = Float32Array.from({ length: 100 }, (_, i) => data_to_prepend.length + i);
+            const aggregates_count = data_to_add.length / 10;
+            buffer.prepend(data_to_prepend);
+            buffer.add(data_to_add);
+
+            const data_valid_view = buffer.getValidView();
+            expect(data_valid_view.length).toBe(data_to_prepend.length + aggregates_count);
+
+            const data_view = buffer.getView();
+            expect(data_view.at(-data_to_prepend.length - aggregates_count - 13)).toBeNaN();
+            expect(data_view.at(-data_to_prepend.length - aggregates_count - 1)).toBeNaN();
+            expect(data_view.at(-data_to_prepend.length - aggregates_count)).toBe(data_to_prepend.at(0));
+            expect(data_view.at(-data_to_prepend.length - aggregates_count + 1)).toBe(data_to_prepend.at(aggregates_count));
+            expect(data_view.at(-data_to_prepend.length)).toBe(data_to_prepend.at(10 * aggregates_count));
+            expect(data_view.at(-data_to_add.length - 1)).toBe(data_to_prepend.at(-1));
+            expect(data_view.at(-data_to_add.length)).toBe(data_to_add.at(0));
+            expect(data_view.at(-1)).toBe(data_to_add.at(-1));
         });
     });
 });

--- a/software/node_server/tests/buffer.test.js
+++ b/software/node_server/tests/buffer.test.js
@@ -48,6 +48,20 @@ describe('AggregatingBuffer class', () => {
             const data_view = buffer.getView();
             expect(data_view.every(value => value === 0)).toBeTruthy();
         });
+
+        test('String w/o initial value', () => {
+            const stringAggregatingBuffer = () => {
+                new AggregatingBuffer(String, 1000, 3, 10);
+            };
+            expect(stringAggregatingBuffer).toThrow(TypeError);
+        });
+
+        test('ArrayBuffer w/o initial value', () => {
+            const arrayBufferAggregatingBuffer = () => {
+                new AggregatingBuffer(ArrayBuffer, 1000, 3, 10);
+            };
+            expect(arrayBufferAggregatingBuffer).toThrow(TypeError);
+        });
     });
 
     describe('buffer values', () => {

--- a/software/node_server/tests/buffer.test.js
+++ b/software/node_server/tests/buffer.test.js
@@ -70,8 +70,19 @@ describe('AggregatingBuffer class', () => {
             buffer.add(data_to_add);
 
             const data_view = buffer.getView();
+            // 1st buffer
             expect(data_view[0]).toBe(1);
             expect(data_view[1]).toBe(2);
+            expect(data_view[999]).toBe(1000);
+            // 2nd buffer
+            expect(data_view[1000]).toBe(1010);
+            expect(data_view[1001]).toBe(1011);
+            expect(data_view[1989]).toBe(1999);
+            expect(data_view[1990]).toBe(2000);
+            expect(data_view[1999]).toBe(2090);
+            // 3rd buffer
+            expect(data_view[2000]).toBe(2100);
+            expect(data_view[2001]).toBe(2101);
             expect(data_view[data_view.length - data_to_add.length - 13]).toBe(data_view.length - 13);
             expect(data_view[data_view.length - data_to_add.length - 1]).toBe(data_view.length - 1);
             expect(data_view[data_view.length - data_to_add.length]).toBe(NaN);


### PR DESCRIPTION
When aggregating binary channel data containing LO and HI data samples for web interface preview: plot line for LO and HI levels for respective data aggregate sample to indicate high digital signal activity.
* add min/max binary data aggregation for DI# channels
* plot min- and max-aggregated values for DI# channels
* align data buffer implementations of server and client side
* buffer performance optimizations
* extend buffer test coverage

Depends on: #91
Implements: #8